### PR TITLE
Not downloading srtm if all data already downloaded

### DIFF
--- a/geohealthaccess/srtm.py
+++ b/geohealthaccess/srtm.py
@@ -1,6 +1,7 @@
 """Download and preprocess elevation data from the SRTM."""
 
 from pkg_resources import resource_string, resource_filename
+import os
 
 import requests
 import geopandas as gpd
@@ -137,10 +138,12 @@ def download(geom, output_dir, username, password, show_progress=True,
         List of downloaded SRTM tiles.
     """
     tiles = required_tiles(geom)
-    with requests.Session() as session:
-        authentify(session, username, password)
-        for tile in tiles:
-            url = DOWNLOAD_URL + tile
-            download_from_url(
-                session, url, output_dir, show_progress, overwrite)
+    n_files = os.listdir(output_dir)
+    if len(tiles) > len(n_files):
+        with requests.Session() as session:
+            authentify(session, username, password)
+            for tile in tiles:
+                url = DOWNLOAD_URL + tile
+                download_from_url(
+                    session, url, output_dir, show_progress, overwrite)
     return tiles


### PR DESCRIPTION
For elevation data there is typically a high number of files to download and there was no check on emptyness of directory before download (I gather to be able to resume when connection was interrupted). As unzipping happens right after download is complete and original zip are deleted, it meant that after initial download, relaunching geohealthaccess-download was redoing the full extraction of zip files in the directory.

I added a test in srtm.download to only download if there are less files in the directory than expected tiles.

This does not check on the nature of the tiles.